### PR TITLE
highlight matching braces and parens

### DIFF
--- a/frontend/src/containers/CodeEditor/index.tsx
+++ b/frontend/src/containers/CodeEditor/index.tsx
@@ -88,6 +88,11 @@ class CodeEditor extends React.Component<Props, CodeEditorState> {
                 increaseIndentPattern: /^.*\{[^}\"']*$/,
                 decreaseIndentPattern: /^(.*\*\/)?\s*\}[;\s]*$/
             },
+            brackets: [
+                ['{','}'],
+                ['(', ')']
+            ],
+            autoClosingPairs: [], // overrides autoclosing, disables autoclosing
         });
         monaco.languages.registerCompletionItemProvider('elementaryjs', {
             // A hacky way to get rid of autocomplete suggestions completely.


### PR DESCRIPTION
![highlight-parens-braces](https://user-images.githubusercontent.com/25542608/52546144-e7d8e980-2d8a-11e9-9dc0-dbcc85a73861.gif)

- Resolves #83 
- Highlights matching braces and parens without autocompleting them.