### PR TITLE
Add alternate button for Login for styling

### DIFF
--- a/frontend/src/loginButton.tsx
+++ b/frontend/src/loginButton.tsx
@@ -27,6 +27,17 @@ const alternateLogoutButton = (onClickProp?: { onClick: () => void }) => {
     );
 };
 
+const alternateLoginButton = (onClickProp? : {onClick: () => void}) => {
+    if (typeof onClickProp === 'undefined') {
+        return (<Button color="inherit">Login</Button>);
+    }
+    return (
+        <Button color="inherit" onClick={onClickProp.onClick}>
+            <Typography color="inherit" variant="button">Login with Google</Typography>
+        </Button>
+    );
+}
+
 type GoogleLogoutButtonProps = {
     show: boolean, // whether to show it or not
     onClick: () => void, // when they press log out button
@@ -132,12 +143,13 @@ class LoginLogout extends React.Component<{}, LoginLogoutState> {
                 </Typography>,
                 <GoogleLogoutButton key="logout" show={loggedIn} onClick={() => this.onLogout()} />,
                 <GoogleLogin key="login"
-                        style={{display: loggedIn ? "none" : "" }}
+                        style={{display: loggedIn ? 'none' : ''}}
                         clientId={LOGIN_CLIENT_ID}
                         onSuccess={(resp) => this.onSuccess(resp)}
                         onFailure={this.onFailure}
                         prompt="select_account" // always prompts user to select a specific account
                         isSignedIn
+                        render={alternateLoginButton}
                     />
             ]
         );

--- a/frontend/src/loginButton.tsx
+++ b/frontend/src/loginButton.tsx
@@ -17,12 +17,9 @@ import { connect } from './reactrx';
 import './static/styles/body.css';
 
 const alternateLogoutButton = (onClickProp?: { onClick: () => void }) => {
-    if (typeof onClickProp === 'undefined') {
-        return (<Button color="inherit">Logout</Button>);
-    }
-    return (
+    return !onClickProp ? (<Button color="inherit">Logout</Button>) : (
         <Button color="inherit" onClick={onClickProp.onClick}>
-            <Typography color="inherit" variant="button">Sign out</Typography>
+            <Typography color="inherit" variant="button">Sign Out</Typography>
         </Button>
     );
 };

--- a/frontend/src/loginButton.tsx
+++ b/frontend/src/loginButton.tsx
@@ -141,7 +141,7 @@ class LoginLogout extends React.Component<{}, LoginLogoutState> {
                         onFailure={this.onFailure}
                         prompt="select_account" // always prompts user to select a specific account
                         isSignedIn
-                        render={alternateLoginButton}
+                        render={!loggedIn ? alternateLoginButton : undefined}
                     />
             ]
         );

--- a/frontend/src/loginButton.tsx
+++ b/frontend/src/loginButton.tsx
@@ -22,15 +22,13 @@ const alternateLogoutButton = (onClickProp?: { onClick: () => void }) => {
             <Typography color="inherit" variant="button">Sign Out</Typography>
         </Button>
     );
-};
-
-const alternateLoginButton = (onClickProp? : {onClick: () => void}) => {
+}, alternateLoginButton = (onClickProp? : {onClick: () => void}) => {
     return !onClickProp ? (<Button color="inherit">Login</Button>) : (
         <Button color="inherit" onClick={onClickProp.onClick}>
             <Typography color="inherit" variant="button">Login with Google</Typography>
         </Button>
     );
-}
+};
 
 type GoogleLogoutButtonProps = {
     show: boolean, // whether to show it or not

--- a/frontend/src/loginButton.tsx
+++ b/frontend/src/loginButton.tsx
@@ -28,10 +28,7 @@ const alternateLogoutButton = (onClickProp?: { onClick: () => void }) => {
 };
 
 const alternateLoginButton = (onClickProp? : {onClick: () => void}) => {
-    if (typeof onClickProp === 'undefined') {
-        return (<Button color="inherit">Login</Button>);
-    }
-    return (
+    return !onClickProp ? (<Button color="inherit">Login</Button>) : (
         <Button color="inherit" onClick={onClickProp.onClick}>
             <Typography color="inherit" variant="button">Login with Google</Typography>
         </Button>


### PR DESCRIPTION
Fixed #116 

Following the implementation of the logout button, I added an `alternateLoginButton` containing MUI typography and button properties:

```typescript
const alternateLoginButton = (onClickProp? : {onClick: () => void}) => {
    if (typeof onClickProp === 'undefined') {
        return (<Button color="inherit">Login</Button>);
    }
    return (
        
        <Button color="inherit" onClick={onClickProp.onClick}>
            <Typography color="inherit" variant="button">Login with Google</Typography>
        </Button>
    );
}
```

Once we had access to this, using this in the `GoogleLoginButton` component simply required rendering this.

This is the toolbar looks like now:
![Ocelot tool bar](https://user-images.githubusercontent.com/49038287/91681102-3af7c600-eb02-11ea-8737-867109e77a53.png)
 
Due to the length of the button content, I considered replacing `LOGIN WITH GOOGLE` with simply `GOOGLE LOGIN` but I leave that to the maintainers to decide.