### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 MAINTAINER Arjun Guha <arjun@cs.umass.edu>
 WORKDIR /root
 
 RUN apt-get update -y
 RUN apt-get install -y curl build-essential
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
 RUN apt-get update && apt-get -y install yarn


### PR DESCRIPTION
NodeJS 8 is deprecated, so I think we should switch to NodeJS 10. Ubuntu 20.04 is out so I think it would be a good idea to replace Ubuntu 18.04 as well.