### PR TITLE
Fix local logging bug with Morgan

### DIFF
--- a/backend/ts/index.ts
+++ b/backend/ts/index.ts
@@ -522,6 +522,8 @@ morgan.token('ejsversion', (req, res) => {
   return 'notprovided'
 });
 
+paws.use(bodyParser.json()); // parse all incoming json data
+
 paws.use(morgan(
   ':method :url :status :username ocelot-:ocelotversion ejs-:ejsversion :res[content-length] - :response-time ms',
   {
@@ -537,8 +539,6 @@ origin: [
   'http://localhost:8080',
   'http://localhost:8081',
 ]}));
-
-paws.use(bodyParser.json()); // parse all incoming json data
 
 
 type Body = {


### PR DESCRIPTION
Fixes a small bug with logging for the backend when run locally.

I wrote a [comment under an issue](https://github.com/umass-compsci220/Ocelot/issues/131#issuecomment-702975917) some time back about a small bug related to running the backend locally (the deployed backend does not have this bug). 
When the frontend makes any request to the backend that is run locally, Morgan would error out and find that there is no `body` to the request (`req.body` would be `undefined`). It's because `paws.use(bodyParser.json());` is called after `paws.use(morgan(...));`. This fixes the bug by calling   `paws.use(bodyParser.json());` before  `paws.use(morgan(...));`.

This bug doesn't show up on the deployed version because Google Cloud Functions apparently parse the request behind the scenes.
